### PR TITLE
Make country code lookup caseless

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,6 @@
 max-line-length=100
 import-order-style=pycharm
 application_import_names=pypopulation,tests
-per-file-ignores=tests/*:ANN
+per-file-ignores=
+    # Ignore type annotations and line length in tests
+    tests/*:ANN,E501

--- a/pypopulation/implementation.py
+++ b/pypopulation/implementation.py
@@ -31,31 +31,37 @@ def _initialize() -> t.Tuple[PopulationMap, PopulationMap]:
     return alpha_2, alpha_3
 
 
+def _normalize(country_code: str) -> str:
+    """Normalize `country_code` casing."""
+    return country_code.upper()
+
+
 def get_population(country_code: str) -> t.Optional[int]:
     """
-    Get population for either Alpha-2 or Alpha-3 `country_code`.
+    Get population for either Alpha-2 or Alpha-3 `country_code` caseless.
 
     None if `country_code` does not exist in either map.
     """
+    normal_code = _normalize(country_code)
     a2_map, a3_map = _initialize()
-    return a2_map.get(country_code) or a3_map.get(country_code)
+    return a2_map.get(normal_code) or a3_map.get(normal_code)
 
 
 def get_population_a2(country_code: str) -> t.Optional[int]:
     """
-    Get population for Alpha-2 `country_code`.
+    Get population for Alpha-2 `country_code` caseless.
 
     None if `country_code` does not exist in the map.
     """
     a2_map, _ = _initialize()
-    return a2_map.get(country_code)
+    return a2_map.get(_normalize(country_code))
 
 
 def get_population_a3(country_code: str) -> t.Optional[int]:
     """
-    Get population for Alpha-3 `country_code`.
+    Get population for Alpha-3 `country_code` caseless.
 
     None if `country_code` does not exist in the map.
     """
     _, a3_map = _initialize()
-    return a3_map.get(country_code)
+    return a3_map.get(_normalize(country_code))

--- a/pypopulation/implementation.py
+++ b/pypopulation/implementation.py
@@ -42,9 +42,7 @@ def get_population(country_code: str) -> t.Optional[int]:
 
     None if `country_code` does not exist in either map.
     """
-    normal_code = _normalize(country_code)
-    a2_map, a3_map = _initialize()
-    return a2_map.get(normal_code) or a3_map.get(normal_code)
+    return get_population_a2(country_code) or get_population_a3(country_code)
 
 
 def get_population_a2(country_code: str) -> t.Optional[int]:

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -109,29 +109,15 @@ class TestImplementation(unittest.TestCase):
     @patch("pypopulation.implementation._initialize", mock_initialize)
     def test_alpha_2_lookup(self):
         """Find populations for 'AA' but not 'BBB' using `get_population_a2`."""
-        pairs = (
-            ("", None),
-            ("A", None),
-            ("AA", 1),
-            ("AAA", None),
-            ("B", None),
-            ("BB", None),
-            ("BBB", None),
-        )
-        self.check_pairs(pairs, imp.get_population_a2)
+        none_pairs = [(code, None) for code in ("", "a", "A", "b", "B")]
+        good_pairs = [(code, 1) for code in ("aa", "aA", "AA")]
+        self.check_pairs(none_pairs + good_pairs, imp.get_population_a2)
 
     @patch("pypopulation.implementation._initialize", mock_initialize)
     def test_alpha_3_lookup(self):
         """Find populations for 'BBB' but not 'AA' using `get_population_a3`."""
-        pairs = (
-            ("", None),
-            ("A", None),
-            ("AA", None),
-            ("AAA", None),
-            ("B", None),
-            ("BB", None),
-            ("BBB", 2),
-        )
-        self.check_pairs(pairs, imp.get_population_a3)
+        none_pairs = [(code, None) for code in ("", "a", "A", "b", "B")]
+        good_pairs = [(code, 2) for code in ("bbb", "bbB", "BBB")]
+        self.check_pairs(none_pairs + good_pairs, imp.get_population_a3)
 
     # endregion

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -65,6 +65,11 @@ class TestImplementation(unittest.TestCase):
             with self.subTest(code=code, expected_population=expected_population):
                 self.assertEqual(expected_population, func(code))
 
+    def test_normalize(self):
+        """The `_normalize_` functions makes all strings uppercase."""
+        pairs = [("", ""), (" ", " "), ("a", "A"), ("A", "A"), ("aBc", "ABC")]
+        self.check_pairs(pairs, imp._normalize)
+
     @patch("pypopulation.implementation._initialize", mock_initialize)
     def test_general_lookup(self):
         """Find populations for both 'AA' and 'BBB' using `get_population`."""


### PR DESCRIPTION
Closes #7. All country codes are now normalized to upper case before querying the dicts.

Additionally, I've rewritten the lookup tests significantly. I believe the new approach is better, it splits the tests into more functions and avoids the endless ugly vertical lists.