### PR TITLE
Improve build & release methodology

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install build tools & build
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel
+        python -m pip install setuptools wheel
         python setup.py sdist bdist_wheel
 
     - name: Publish to PyPI

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include pypopulation/resources/*

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
     author_email="kay.wzrd@gmail.com",
     url="https://github.com/kwzrd/pypopulation",
     packages=["pypopulation"],
+    package_data={"pypopulation": ["resources/countries.json"]},
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="kwzrd",
     author_email="kay.wzrd@gmail.com",
     url="https://github.com/kwzrd/pypopulation",
-    packages=setuptools.find_packages(),
+    packages=["pypopulation"],
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This PR brings several improvements to the build & release methodology.

**Explicitly only release the `pypopulation` package**
  * This is more transparent than using automatic package discovery
  * The `tests` package is (intentionally) no longer included in the distribution

**Pass `package_data` to `setup` instead of having a `MANIFEST.in` file**
  * Removes the need for yet another config file ~ setup is now configured in `setup.py` only!

90f79fb then makes the Actions YAML file a little more consistent with how we invoke `pip`.