### PR TITLE
Actions: add Python 3.9 to test strategy matrix

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Closes #24 

Extends the testing strategy matrix with Python 3.9 to ensure that we run tests on all supported versions.